### PR TITLE
fix issue #15 'int' object is not iterable

### DIFF
--- a/telescope/utils/model.py
+++ b/telescope/utils/model.py
@@ -252,8 +252,9 @@ class Telescope(object):
 
                 ''' Update min and max scores '''
                 _scores = [a.alnscore for a in _mapped]
-                _minAS = min(_minAS, *_scores)
-                _maxAS = max(_maxAS, *_scores)
+                if len(_scores) > 0:
+                    _minAS = min(_minAS, *_scores)
+                    _maxAS = max(_maxAS, *_scores)
 
                 ''' Check whether fragment overlaps annotation '''
                 overlap_feats = list(map(assign, _mapped))


### PR DESCRIPTION
fix issue #15 

```
File "/app/software/Telescope/1.0.3-20230222-gfbf-2022b/lib/python3.10/site-packages/telescope/utils/model.py", line 255, in _load_sequential
    _minAS = min(_minAS, *_scores)
TypeError: 'int' object is not iterable
```