### PR TITLE
PATCH: np int conversion

### DIFF
--- a/telescope/utils/model.py
+++ b/telescope/utils/model.py
@@ -676,7 +676,7 @@ class TelescopeLikelihood(object):
         # Y[i] is the ambiguity indicator for fragment i, where Y[i]=1 if
         # fragment i is aligned to multiple transcripts and Y[i]=0 otherwise.
         # Store as N x 1 matrix
-        self.Y = (self.Q.count(1) > 1).astype(np.uint8)
+        self.Y = (self.Q.count(1) > 1).astype(int)
         self._yslice = self.Y[:,0].nonzero()[0]
 
         # Log-likelihood score
@@ -856,10 +856,10 @@ class TelescopeLikelihood(object):
             assignments = v.norm(1)
         elif method == 'unique':
             # Zero all rows that are ambiguous
-            assignments = _z.multiply(1 - self.Y).ceil().astype(np.uint8)
+            assignments = _z.multiply(1 - self.Y).ceil().astype(int)
         elif method == 'all':
             # Return all nonzero elements
-            assignments = _z.apply_func(lambda x: 1 if x > 0 else 0).astype(np.uint8)
+            assignments = _z.apply_func(lambda x: 1 if x > 0 else 0).astype(int)
 
         assignments = csr_matrix(assignments)
         return assignments

--- a/telescope/utils/sparse_plus.py
+++ b/telescope/utils/sparse_plus.py
@@ -53,13 +53,13 @@ class csr_matrix_plus(scipy.sparse.csr_matrix):
 
     def _norm_loop(self, axis=None):
         if axis is None:
-            ret = self.copy().astype(np.float)
+            ret = self.copy().astype(float)
             ret.data /= sum(ret)
             return ret
         elif axis == 0:
             raise NotImplementedError
         elif axis == 1:
-            ret = self.copy().astype(np.float)
+            ret = self.copy().astype(float)
             rowiter = zip(ret.indptr[:-1], ret.indptr[1:], ret.sum(1).A1)
             for d_start, d_end, d_sum in rowiter:
                 if d_sum != 0:
@@ -89,7 +89,7 @@ class csr_matrix_plus(scipy.sparse.csr_matrix):
     def _scale(self, axis=None):
         if axis is None:
             return type(self)(self.multiply(1. / self.max()))
-            # ret = self.copy().astype(np.float)
+            # ret = self.copy().astype(float)
             # return ret / ret.max()
         elif axis == 0:
             raise NotImplementedError


### PR DESCRIPTION
numpy int and float conversion throws errors in new python version. Updated syntax to fix problem (ie astype(np.int) -> astype(int))